### PR TITLE
Import Term and Polynomial

### DIFF
--- a/src/SIMDPolynomials.jl
+++ b/src/SIMDPolynomials.jl
@@ -1,6 +1,8 @@
 module SIMDPolynomials
 
 using MultivariatePolynomials
+const Term = MultivariatePolynomials.Term
+const Polynomial = MultivariatePolynomials.Polynomial
 export Uninomial, Uniterm, Poly
 export PackedMonomial, Monomial, Term, MPoly
 export terms, coeffs, content, contprim


### PR DESCRIPTION
There're not exported anymore to avoid class with `DynamicPolynomials.Polynomial` which has the same name.